### PR TITLE
Audit Fix V2

### DIFF
--- a/src/CrossDexImpl.sol
+++ b/src/CrossDexImpl.sol
@@ -93,7 +93,9 @@ contract CrossDexImpl is ICrossDex, UUPSUpgradeable, OwnableUpgradeable {
 
     function checkTickSizeRoles(address account) external view override {
         // check account is tick size setter
-        if (tickSizeSetter != account) revert CrossDexUnauthorizedChangeTickSizes(account);
+        if (tickSizeSetter == address(0) || tickSizeSetter != account) {
+            revert CrossDexUnauthorizedChangeTickSizes(account);
+        }
     }
 
     function isMarket(address market) public view returns (bool) {

--- a/src/lib/List.sol
+++ b/src/lib/List.sol
@@ -64,6 +64,9 @@ library List {
         return result;
     }
 
+    // WARNING: This function assumes that the list is strictly sorted in ascending order.
+    // It will only work correctly if values are inserted in ascending order,
+    // typically using the designated insertion mechanism that maintains sort order.
     function findASCPrev(U256 storage _list, uint256 _data, uint256[2] memory _adjacent, uint256 _findMaxCount)
         internal
         view
@@ -81,14 +84,16 @@ library List {
             uint256 current = _ensureAdjacentForPush(_list, _adjacent);
             unchecked {
                 if (current < _data) {
-                    while (current != 0 && --_findMaxCount != 0) {
+                    while (current != 0 && _findMaxCount != 0) {
                         current = _list.nodes[current].next;
                         if (current > _data) return _list.nodes[current].prev;
+                        --_findMaxCount;
                     }
                 } else {
-                    while (current != 0 && --_findMaxCount != 0) {
+                    while (current != 0 && _findMaxCount != 0) {
                         current = _list.nodes[current].prev;
                         if (current < _data) return current;
+                        --_findMaxCount;
                     }
                 }
             }
@@ -96,6 +101,9 @@ library List {
         }
     }
 
+    // WARNING: This function assumes that the list is strictly sorted in descending order.
+    // It will only work correctly if values are inserted in descending order,
+    // typically using the designated insertion mechanism that maintains sort order.
     function findDESCPrev(U256 storage _list, uint256 _data, uint256[2] memory _adjacent, uint256 _findMaxCount)
         internal
         view

--- a/test/TestList.t.sol
+++ b/test/TestList.t.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.20;
+
+import "../src/lib/List.sol";
+import {Test, console} from "forge-std/Test.sol";
+
+contract TestList is Test {
+    using List for List.U256;
+
+    List.U256 private sell_list;
+    List.U256 private buy_list;
+
+    function setUp() public {}
+
+    function test_poc() external {
+        insert(20, 1);
+        insert(30, 1);
+        insert(25, 1);
+        uint256[] memory values = sell_list.values();
+        assertEq(values.length, 3);
+        assertEq(values[0], 20);
+        assertEq(values[1], 25);
+        assertEq(values[2], 30);
+    }
+
+    function testFuzz_poc_sell(uint256[] calldata values) external {
+        uint256 length = values.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (values[i] == 0) continue;
+            insert(values[i], length);
+        }
+        uint256 len = List.length(sell_list);
+        console.log("sell_list.length", len);
+
+        uint256 before = 0;
+        for (uint256 i = 0; i < len; i++) {
+            uint256 value = sell_list.at(i);
+            assertGt(value, before);
+            before = value;
+        }
+    }
+
+    function testFuzz_poc_buy(uint256[] memory values) external {
+        uint256 length = values.length;
+        for (uint256 i = 0; i < length; i++) {
+            if (values[i] == 0) continue;
+            if (values[i] == type(uint256).max) --values[i];
+            insertDESC(values[i], length);
+        }
+        uint256 len = List.length(buy_list);
+        console.log("buy_list.length", len);
+
+        uint256 before = type(uint256).max;
+        for (uint256 i = 0; i < len; i++) {
+            uint256 value = buy_list.at(i);
+            assertLt(value, before);
+            before = value;
+        }
+    }
+
+    function insert(uint256 value, uint256 maxMatchCount) public {
+        uint256[2] memory adjacent = [uint256(0), uint256(0)];
+        uint256 prevPrice = sell_list.findASCPrev(value, adjacent, maxMatchCount);
+        require(value >= prevPrice, "value < prevPrice");
+        sell_list.insert(value, prevPrice);
+    }
+
+    function insertDESC(uint256 value, uint256 maxMatchCount) public {
+        uint256[2] memory adjacent = [uint256(0), uint256(0)];
+        uint256 prevPrice = buy_list.findDESCPrev(value, adjacent, maxMatchCount);
+        require(prevPrice == 0 || prevPrice >= value, "prevPrice < value");
+        buy_list.insert(value, prevPrice);
+    }
+}


### PR DESCRIPTION
* CRD-02 | Traversal Fails When `_findMaxCount` Is Set to One Due to Premature Decrement

* CRD-01 | Zero Address Passes Role Check When Role Is Uninitialized

* [test] CRD-03 | Incorrect Predecessor Search Due to Lack of Order Enforcement in Linked List

* CRD-03 | Incorrect Predecessor Search Due to Lack of Order Enforcement in Linked List