### PR TITLE
CRD-02 | Traversal Fails When `_findMaxCount` Is Set to One Due to Pr…

### DIFF
--- a/src/lib/List.sol
+++ b/src/lib/List.sol
@@ -121,15 +121,17 @@ library List {
             uint256 current = _ensureAdjacentForPush(_list, _adjacent);
             unchecked {
                 if (current > _data) {
-                    while (current != 0 && --_findMaxCount != 0) {
+                    while (current != 0 && _findMaxCount != 0) {
                         current = _list.nodes[current].next;
                         if (_data > current) return _list.nodes[current].prev;
+                        --_findMaxCount;
                     }
                 } else {
                     // current < _data
-                    while (current != 0 && --_findMaxCount != 0) {
+                    while (current != 0 && _findMaxCount != 0) {
                         current = _list.nodes[current].prev;
                         if (_data < current) return current;
+                        --_findMaxCount;
                     }
                 }
             }

--- a/test/TestList.t.sol
+++ b/test/TestList.t.sol
@@ -12,7 +12,7 @@ contract TestList is Test {
 
     function setUp() public {}
 
-    function test_poc() external {
+    function test_poc_asc() external {
         insert(20, 1);
         insert(30, 1);
         insert(25, 1);
@@ -21,6 +21,17 @@ contract TestList is Test {
         assertEq(values[0], 20);
         assertEq(values[1], 25);
         assertEq(values[2], 30);
+    }
+
+    function test_poc_desc() external {
+        insertDESC(20, 1);
+        insertDESC(30, 1);
+        insertDESC(25, 1);
+        uint256[] memory values = buy_list.values();
+        assertEq(values.length, 3);
+        assertEq(values[0], 30);
+        assertEq(values[1], 25);
+        assertEq(values[2], 20);
     }
 
     function testFuzz_poc_sell(uint256[] calldata values) external {


### PR DESCRIPTION
Addressed missing update for findDESCPrev related to CRD-02 | Traversal Fails When _findMaxCount Is Set to One Due to Premature Decrement.
The issue has now been corrected to ensure consistent behavior across both findASCPrev and findDESCPrev.