### PR TITLE
fix(audit): V3 컨트랙트 감사 결과 반영

### DIFF
--- a/docs/FEES.md
+++ b/docs/FEES.md
@@ -8,16 +8,67 @@ This document explains:
 - how fees affect deposits, matching, and refunds
 - the two shipped fee policies (`V2Compat` and `V3Split`)
 - how to configure and upgrade fee controllers safely
+- the complete cross-contract fee flow with diagrams
+- storage patterns used across contracts
+- integration guidance for external systems
 
 ## 📋 Table of Contents
 
+- [Contract Responsibility Map](#-contract-responsibility-map)
 - [FeeController Overview](#-feecontroller-overview)
-- [Fee Lifecycle in a Trade](#-fee-lifecycle-in-a-trade)
+- [Complete Cross-Contract Fee Flow](#-complete-cross-contract-fee-flow)
+- [Fee Lifecycle per Order Type](#-fee-lifecycle-per-order-type)
 - [Buy Deposits: "Volume With Fee"](#-buy-deposits-volume-with-fee)
 - [FeeControllerV2Compat (V2-like 4-bps model)](#-feecontrollerv2compat-v2-like-4-bps-model)
 - [FeeControllerV3Split (taker-only 3-way split)](#-feecontrollerv3split-taker-only-3-way-split)
+- [Cancel and Refund Paths](#-cancel-and-refund-paths)
+- [Storage Patterns](#-storage-patterns)
 - [Allow-list and Safety Checks](#-allow-list-and-safety-checks)
 - [Configuration Examples](#-configuration-examples)
+- [Integration Guide](#-integration-guide)
+
+---
+
+## 🗺️ Contract Responsibility Map
+
+Fee logic spans **5 contracts**, each with a specific role:
+
+| Contract | Role | Fee Responsibilities |
+|---|---|---|
+| **CrossDexImplV3** | Global registry | Maintains FeeController allow-list (`_allowedFeeControllers`). Validates FeeController addresses via ERC-165 before allowing. |
+| **CrossDexRouterV3** | User-facing entry point | Calls `calcBuyVolumeWithFee()` to compute fee-inclusive deposit amounts for BUY orders. Transfers fee-inclusive QUOTE to the Pair. |
+| **MarketImplV3** | Per-quote-token factory | Propagates FeeController changes to Pairs. Validates against CrossDex allow-list on FeeController set. |
+| **PairImplV3** | Order book + matching engine | Orchestrates fee flow: stores `order.feeBps` at creation, calls FeeController via `delegatecall` during matching, manages reserves, handles refunds on cancel. |
+| **FeeController** (V2Compat / V3Split) | Fee policy (delegatecall target) | Pure policy code: calculates fees, accumulates per-tx totals in transient storage, transfers fees to collectors. Runs in Pair's storage context. |
+
+### Contract Interaction Diagram
+
+```mermaid
+graph TB
+    User[User / Integrator]
+    Router[CrossDexRouterV3<br/><i>Entry Point</i>]
+    CrossDex[CrossDexImplV3<br/><i>Global Registry</i>]
+    Market[MarketImplV3<br/><i>Per-Quote Market</i>]
+    Pair[PairImplV3<br/><i>Order Book + Matching</i>]
+    FeeCtrl[FeeController<br/><i>V2Compat or V3Split</i>]
+
+    User -->|"submit / cancel"| Router
+    Router -->|"calcBuyVolumeWithFee()"| Pair
+    Router -->|"transfer QUOTE (fee-inclusive)"| Pair
+    Router -->|"isPair() validation"| CrossDex
+    CrossDex -->|"setFeeControllerAllow()"| CrossDex
+    Market -->|"checkFeeControllerAllowed()"| CrossDex
+    Pair -->|"delegatecall: all fee ops"| FeeCtrl
+    Pair -->|"checkFeeControllerAllowed()"| Market
+
+    style CrossDex fill:#e1f5ff
+    style Router fill:#fff4e1
+    style Market fill:#e8f5e9
+    style Pair fill:#fce4ec
+    style FeeCtrl fill:#ede7f6
+```
+
+---
 
 ## 🧩 FeeController Overview
 
@@ -37,35 +88,251 @@ The Pair calls FeeController methods via `delegatecall` wrappers:
 FeeController is treated as **pure policy code**. By running it in Pair context:
 
 - the controller can store configuration in Pair storage (namespaced via ERC-7201)
-- per-tx accumulators can use transient storage (EIP-1153) without touching Pair’s permanent state
+- per-tx accumulators can use transient storage (EIP-1153) without touching Pair's permanent state
 - Pair upgrades can keep the matching engine stable while the fee policy evolves
 
-## 🔄 Fee Lifecycle in a Trade
+### IFeeController Interface
 
-Matching flow in `PairImplV3` (simplified):
+```solidity
+uint256 constant BPS_DENOMINATOR = 10000;
+
+interface IFeeController {
+    function initialize(address quote, uint256 denominator, bytes memory initData) external;
+    function calcBuyVolumeWithFeeByOrder(bool isMaker, Order memory order) external view returns (uint256);
+    function calcBuyVolumeWithFee(bool isMaker, uint256 volume) external view returns (uint256);
+    function recordMatch(
+        uint256 takerId, uint256 makerId,
+        Order memory taker, Order memory maker,
+        uint256 tradeAmount, uint256 tradeQuoteAmount
+    ) external returns (uint256 makerFee);
+    function settleFees() external returns (uint256 takerFee);
+    function sellerMakerFeeBps() external view returns (uint32);
+    function buyerMakerFeeBps() external view returns (uint32);
+    function getEffectiveFees() external view returns (uint32, uint32, uint32, uint32);
+    function getConfigId() external view returns (bytes32);
+    function getStorage() external view returns (bytes memory);
+}
+```
+
+### Delegatecall Wrappers in PairImplV3
+
+All fee operations go through private wrapper functions that use `Address.functionDelegateCall`:
+
+| Wrapper Function | Delegates To | Returns |
+|---|---|---|
+| `_feeControllerInitialize(bytes)` | `initialize()` | — |
+| `_feeControllerCalcBuyVolumeWithFee(bool, uint256)` | `calcBuyVolumeWithFee()` | `uint256 buyVolume` |
+| `_feeControllerCalcBuyVolumeWithFeeOrder(bool, Order)` | `calcBuyVolumeWithFeeByOrder()` | `uint256 buyVolume` |
+| `_feeControllerRecordMatch(...)` | `recordMatch()` | `uint256 makerFee` |
+| `_feeControllerSettleFees()` | `settleFees()` | `uint256 takerFee` |
+| `_feeControllerSellerMakerFeeBps()` | `sellerMakerFeeBps()` | `uint32` |
+| `_feeControllerBuyerMakerFeeBps()` | `buyerMakerFeeBps()` | `uint32` |
+
+---
+
+## 🔄 Complete Cross-Contract Fee Flow
+
+### End-to-End: SELL Limit Order
 
 ```mermaid
 sequenceDiagram
+    participant U as User
     participant R as Router
     participant P as PairImplV3
-    participant F as FeeController (delegatecall)
-    participant Q as QUOTE token
+    participant F as FeeController<br/>(delegatecall)
+    participant Q as QUOTE Token
+    participant B as BASE Token
 
-    R->>P: submitLimitOrder / submitMarketOrder
-    loop for each fill
-        P->>F: recordMatch(takerId, taker, maker, tradeAmount, tradeQuoteAmount)
-        F-->>P: makerFee (uint256)
-        Note over P: Pair transfers BASE/QUOTE to counterparties\nand updates reserves
+    U->>R: submitSellLimit(pair, price, amount, ...)
+    R->>B: transferFrom(user, pair, amount)
+    R->>P: submitLimitOrder(order, ...)
+
+    Note over P: Order creation phase
+    P->>F: sellerMakerFeeBps()
+    F-->>P: feeBps (e.g. 30)
+    Note over P: Store order.feeBps = feeBps<br/>Add to baseReserve
+
+    Note over P: Immediate matching phase<br/>(if crossing BUY orders exist)
+    loop For each fill (sell taker vs buy maker)
+        P->>F: recordMatch(takerId, makerId, taker, maker, tradeAmount, tradeQuoteAmount)
+        Note over F: Calculate makerFee = tradeQuoteAmount * maker.feeBps / 10000<br/>Calculate takerFee = tradeQuoteAmount * takerBps / 10000<br/>Accumulate in transient storage
+        F-->>P: makerFee
+        Note over P: subQuoteReserve(tradeQuoteAmount + makerFee)<br/>Transfer BASE to buy-maker
     end
+
     P->>F: settleFees()
-    F->>Q: transfer fees (feeCollector / creator / etc)
-    F-->>P: takerFeeTotal (uint256)
+    Note over F: Read accumulated fees from transient storage<br/>Clear transient storage<br/>Transfer total fees to feeCollector
+    F->>Q: transfer(feeCollector, totalFee)
+    F-->>P: takerFee
+
+    Note over P: Transfer earned QUOTE to seller<br/>(earnQuoteAmount - takerFee)
+    P->>Q: transfer(seller, earnQuoteAmount - takerFee)
 ```
 
-Important:
+### End-to-End: BUY Limit Order
 
-- **All fee transfers are done in QUOTE token**.
-- `recordMatch` can also perform immediate transfers (e.g., maker rebates in V3Split).
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant R as Router
+    participant P as PairImplV3
+    participant F as FeeController<br/>(delegatecall)
+    participant Q as QUOTE Token
+    participant B as BASE Token
+
+    U->>R: submitBuyLimit(pair, price, amount, ...)
+
+    Note over R: Fee-inclusive deposit calculation
+    R->>P: calcBuyVolumeWithFee(volume)
+    P->>F: calcBuyVolumeWithFee(isMaker=false, volume)
+    F-->>P: volumeWithFee
+    P-->>R: volumeWithFee
+
+    R->>Q: transferFrom(user, pair, volumeWithFee)
+    R->>P: submitLimitOrder(order, ...)
+
+    Note over P: Order creation phase
+    P->>F: buyerMakerFeeBps()
+    F-->>P: feeBps (e.g. 20)
+    Note over P: Store order.feeBps = feeBps
+    P->>F: calcBuyVolumeWithFeeByOrder(isMaker=true, order)
+    F-->>P: reserveAmount (volume + makerFee)
+    Note over P: Add reserveAmount to quoteReserve
+
+    Note over P: Immediate matching phase<br/>(if crossing SELL orders exist)
+    loop For each fill (buy taker vs sell maker)
+        P->>F: recordMatch(takerId, makerId, taker, maker, tradeAmount, tradeQuoteAmount)
+        Note over F: Calculate makerFee = tradeQuoteAmount * maker.feeBps / 10000<br/>Calculate takerFee = tradeQuoteAmount * takerBps / 10000<br/>Accumulate in transient storage
+        F-->>P: makerFee
+        Note over P: Transfer QUOTE (- makerFee) to sell-maker<br/>Transfer BASE to buyer
+    end
+
+    P->>F: settleFees()
+    F->>Q: transfer(feeCollector, totalFee)
+    F-->>P: takerFee
+
+    Note over P: Return excess QUOTE to buyer<br/>(if partial fill or price improvement)
+```
+
+### End-to-End: BUY Market Order
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant R as Router
+    participant P as PairImplV3
+    participant F as FeeController<br/>(delegatecall)
+
+    U->>R: submitBuyMarket(pair, quoteVolume, ...)
+
+    Note over R: Fee-inclusive deposit
+    R->>P: calcBuyVolumeWithFee(quoteVolume)
+    P->>F: calcBuyVolumeWithFee(isMaker=false, quoteVolume)
+    F-->>R: volumeWithFee
+
+    R->>P: submitMarketOrder(order, spendAmount=volumeWithFee, ...)
+
+    Note over P: Matching phase<br/>(price sweeps from cheapest SELL)
+    loop For each fill
+        P->>F: recordMatch(...)
+        F-->>P: makerFee
+    end
+
+    P->>F: settleFees()
+    F-->>P: takerFee
+
+    Note over P: Transfer BASE to buyer<br/>Return unused QUOTE to buyer
+```
+
+---
+
+## 📊 Fee Lifecycle per Order Type
+
+### Timing Summary
+
+| Order Type | Fee Reserved At | Fee Charged At | Fee Returned On Cancel |
+|---|---|---|---|
+| **SELL Limit** (maker) | — | Execution (matching) | N/A (BASE returned, no fee) |
+| **SELL Limit** (becomes taker) | — | Immediate matching | N/A |
+| **SELL Market** (always taker) | — | Execution (matching) | N/A (unused BASE returned) |
+| **BUY Limit** (maker) | Order creation (maker fee pre-funded) | Execution (matching) | Yes, via `order.feeBps` |
+| **BUY Limit** (becomes taker) | Order creation (taker fee pre-funded) | Immediate matching | Excess returned |
+| **BUY Market** (always taker) | Submission (taker fee pre-funded by Router) | Execution (matching) | Unused QUOTE returned |
+
+### SELL Order Fee Flow (Detailed)
+
+```
+1. DEPOSIT:  User deposits BASE only (no fee involved)
+             → baseReserve += order.amount
+
+2. CREATION: order.feeBps = sellerMakerFeeBps()
+             (stored for future use if this order becomes a maker)
+
+3. MATCHING (as taker, immediate):
+   For each fill:
+     ├─ recordMatch() → takerFee accumulated (sellerTakerFeeBps)
+     ├─ makerFee returned (from BUY maker's feeBps)
+     └─ quoteReserve -= (tradeQuoteAmount + makerFee)
+
+   settleFees() → takerFee transferred to feeCollector
+   Seller receives: earnQuoteAmount - takerFee
+
+4. MATCHING (as maker, later):
+   For each fill:
+     ├─ recordMatch() → makerFee = tradeQuoteAmount * order.feeBps / 10000
+     └─ makerFee accumulated in transient storage
+
+   Seller receives: tradeQuoteAmount - makerFee
+
+5. CANCEL:   BASE returned to owner
+             baseReserve -= order.amount
+             (No fee involved — fee was never pre-funded for SELL)
+```
+
+### BUY Order Fee Flow (Detailed)
+
+```
+1. DEPOSIT:  Router calculates fee-inclusive amount:
+             volumeWithFee = volume + (volume * takerFeeBps / 10000)
+             User deposits QUOTE including taker fee
+             → quoteReserve += calcBuyVolumeWithFeeByOrder(isMaker=true, order)
+             (Note: reserve uses maker fee, not taker fee)
+
+2. CREATION: order.feeBps = buyerMakerFeeBps()
+             (stored for cancel refund and maker fee calculation)
+
+3. MATCHING (as taker, immediate):
+   For each fill:
+     ├─ recordMatch() → takerFee accumulated (buyerTakerFeeBps)
+     ├─ makerFee returned (from SELL maker's feeBps)
+     └─ BASE transferred to buyer
+
+   settleFees() → takerFee transferred to feeCollector
+   Buyer receives: BASE tokens
+
+4. MATCHING (as maker, later):
+   For each fill:
+     ├─ recordMatch() → makerFee = tradeQuoteAmount * order.feeBps / 10000
+     ├─ makerFee accumulated in transient storage
+     └─ quoteReserve -= (tradeQuoteAmount + makerFee)
+
+   Buyer receives: BASE tokens
+
+5. CANCEL:   QUOTE returned to owner, including maker fee pre-funding:
+             returnQuote = (price * amount / DENOMINATOR)
+             if (order.feeBps != 0):
+                 returnQuote += returnQuote * order.feeBps / BPS_DENOMINATOR
+             quoteReserve -= returnQuote
+```
+
+### Why Taker Fee Is Pre-funded for BUY Limits
+
+A BUY limit order may **immediately cross** existing SELL orders (becoming a taker). The Router cannot know in advance whether the order will be a maker or taker, so it pre-funds with the **taker fee** (which is always >= maker fee).
+
+- If the order matches immediately (taker): taker fee is used
+- If the order rests on the book (maker): excess QUOTE (taker fee - maker fee portion) is returned to the user via `_returnRemainQuote()`
+
+---
 
 ## 🧮 Buy Deposits: "Volume With Fee"
 
@@ -84,6 +351,17 @@ In V3, Router uses:
 
 This ensures BUY submissions have enough QUOTE even if they match immediately.
 
+### Fee Calculation Formula
+
+```
+fee = Math.mulDiv(amount, feeBps, BPS_DENOMINATOR)
+totalWithFee = amount + fee
+```
+
+Where `BPS_DENOMINATOR = 10000` (1 bps = 0.01%).
+
+---
+
 ## 🧾 FeeControllerV2Compat (V2-like 4-bps model)
 
 **Purpose:** match V2 behavior: 4 independent fee rates:
@@ -93,12 +371,24 @@ This ensures BUY submissions have enough QUOTE even if they match immediately.
 - buyer maker fee bps
 - buyer taker fee bps
 
+**Config ID:** `"FeeControllerV2Compat.v1"`
+
 ### Policy rules
 
 - Fees are in **basis points** (BPS), `BPS_DENOMINATOR = 10000`.
 - Validation:
   - `sellerTakerFeeBps >= sellerMakerFeeBps`
   - `buyerTakerFeeBps >= buyerMakerFeeBps`
+  - All bps values < 10000
+
+### Fee Rate Selection Logic
+
+| Who | Role in Match | Fee Rate Used |
+|---|---|---|
+| SELL order | Maker (resting) | `sellerMakerFeeBps` (from `order.feeBps`) |
+| SELL order | Taker (immediate) | `sellerTakerFeeBps` |
+| BUY order | Maker (resting) | `buyerMakerFeeBps` (from `order.feeBps`) |
+| BUY order | Taker (immediate) | `buyerTakerFeeBps` |
 
 ### How maker fees work (V2 compatibility)
 
@@ -114,6 +404,49 @@ Then, during each fill:
 
 The FeeController accumulates maker+taker fees in transient storage and transfers them to `feeCollector` in `settleFees()`.
 
+### recordMatch() Flow (V2Compat)
+
+```
+recordMatch(takerId, makerId, taker, maker, tradeAmount, tradeQuoteAmount):
+  1. First call in a match set:
+     ├─ Store takerId in transient storage
+     ├─ Determine takerFeeBps based on taker.side
+     │   ├─ SELL taker → sellerTakerFeeBps
+     │   └─ BUY taker → buyerTakerFeeBps
+     └─ Cache takerFeeBps in transient storage
+
+  2. Subsequent calls:
+     ├─ Verify takerId matches (safety check)
+     └─ Read cached takerFeeBps
+
+  3. Calculate fees:
+     ├─ makerFee = tradeQuoteAmount * maker.feeBps / 10000
+     ├─ takerFee = tradeQuoteAmount * takerFeeBps / 10000
+     ├─ makerFeeAcc += makerFee   (transient storage)
+     └─ takerFeeAcc += takerFee   (transient storage)
+
+  4. Return makerFee
+```
+
+### settleFees() Flow (V2Compat)
+
+```
+settleFees():
+  1. Read from transient storage:
+     ├─ takerId
+     ├─ makerFeeAcc
+     └─ takerFeeAcc
+
+  2. Effects (CEI pattern):
+     └─ Clear all transient storage slots to 0
+
+  3. Interactions:
+     └─ QUOTE.transfer(feeCollector, makerFeeAcc + takerFeeAcc)
+
+  4. Emit FeeControllerFeesSettled(takerId, feeCollector, totalFee)
+  5. Return takerFeeAcc
+```
+
 ### Refund behavior on cancel (BUY limit)
 
 For a BUY limit order that remains on the book, the deposited QUOTE includes **maker fee pre-funding**.
@@ -124,6 +457,8 @@ On cancellation, Pair refunds:
 
 This is why V2Compat stores maker fee bps in the order itself.
 
+---
+
 ## 🧾 FeeControllerV3Split (taker-only 3-way split)
 
 **Purpose:** a modern policy where **makers pay no fee** and **takers pay a single fee** that is split:
@@ -131,6 +466,8 @@ This is why V2Compat stores maker fee bps in the order itself.
 - creator fee (paid to `creator`)
 - maker rebate (paid immediately to the maker)
 - system fee (paid to `feeCollector`)
+
+**Config ID:** `"FeeControllerV3Split.v1"`
 
 ### Policy rules
 
@@ -143,26 +480,230 @@ This is why V2Compat stores maker fee bps in the order itself.
 - Validation:
   - `creatorShareBps + makerRebateShareBps <= 10000`
 
-### Immediate maker rebate
+### Fee Rate Selection Logic
 
-During `recordMatch`, V3Split computes the taker fee and pays the maker rebate immediately:
+| Who | Role in Match | Fee Rate Used |
+|---|---|---|
+| Any order | Maker (resting) | **0** (no maker fee) |
+| Any order | Taker (immediate) | `takerFeeBps` (uniform) |
 
-- `rebate = takerFee * makerRebateShareBps / 10000`
-- `QUOTE.transfer(maker.owner, rebate)` (executed from Pair context via delegatecall)
+### recordMatch() Flow (V3Split)
 
-This means makers receive rebates **during matching**, not at the end.
+```
+recordMatch(takerId, makerId, taker, maker, tradeAmount, tradeQuoteAmount):
+  1. Validate/set takerId in transient storage (same as V2Compat)
 
-### Settlement
+  2. Calculate taker fee:
+     └─ takerFee = tradeQuoteAmount * takerFeeBps / 10000
 
-In `settleFees()`:
+  3. Accumulate takerFee in transient storage
 
-- `creatorFee = takerFeeTotal * creatorShareBps / 10000`
-- `feeCollectorFee = takerFeeTotal - creatorFee - makerRebatePaidTotal`
+  4. Immediate maker rebate:
+     ├─ rebate = takerFee * makerRebateShareBps / 10000
+     ├─ Accumulate rebate total in transient storage
+     ├─ QUOTE.transfer(maker.owner, rebate)    ← IMMEDIATE TRANSFER
+     └─ Emit FeeControllerV3MakerRebatePaid(makerId, maker.owner, rebate)
 
-Then transfers:
+  5. Return 0 (makerFee is always 0 in V3Split)
+```
 
-- `creatorFee` → `creator`
-- `feeCollectorFee` → `feeCollector`
+> **Important:** Maker rebates are paid **during matching** (inside `recordMatch`), not at settlement. This is a key difference from V2Compat.
+
+### settleFees() Flow (V3Split)
+
+```
+settleFees():
+  1. Read from transient storage:
+     ├─ takerId
+     ├─ takerFeeAccTotal
+     └─ makerRebatePaidTotal
+
+  2. Effects (CEI pattern):
+     └─ Clear all transient storage slots to 0
+
+  3. Calculate distribution:
+     ├─ creatorFee = takerFeeAccTotal * creatorShareBps / 10000
+     └─ feeCollectorFee = takerFeeAccTotal - creatorFee - makerRebatePaidTotal
+
+  4. Interactions:
+     ├─ QUOTE.transfer(creator, creatorFee)
+     └─ QUOTE.transfer(feeCollector, feeCollectorFee)
+
+  5. Emit FeeControllerV3FeesSettled(takerId, totalTakerFee, creatorFee, feeCollectorFee, makerRebatePaidTotal, creator, feeCollector)
+  6. Return takerFeeAccTotal
+```
+
+### Taker Fee Distribution Example
+
+If `takerFeeBps = 100` (1%), `creatorShareBps = 3000` (30%), `makerRebateShareBps = 2000` (20%):
+
+```
+Trade: 10,000 QUOTE
+  ├─ takerFee = 100 QUOTE (1%)
+  │
+  ├─ makerRebate = 20 QUOTE (20% of takerFee) → paid to maker during matching
+  ├─ creatorFee  = 30 QUOTE (30% of takerFee) → paid to creator at settlement
+  └─ systemFee   = 50 QUOTE (remaining 50%)   → paid to feeCollector at settlement
+```
+
+---
+
+## 🔁 Cancel and Refund Paths
+
+### SELL Order Cancel
+
+```
+_cancelOrder(orderId, order):
+  ├─ amount = order.amount (remaining BASE)
+  ├─ baseReserve -= amount
+  └─ BASE.transfer(order.owner, amount)
+
+  No fee involved. SELL orders never pre-fund fees.
+```
+
+### BUY Order Cancel
+
+```
+_cancelOrder(orderId, order):
+  ├─ returnQuoteAmount = price * amount / DENOMINATOR
+  ├─ if (order.feeBps != 0):
+  │   └─ returnQuoteAmount += returnQuoteAmount * order.feeBps / BPS_DENOMINATOR
+  ├─ quoteReserve -= returnQuoteAmount
+  └─ QUOTE.transfer(order.owner, returnQuoteAmount)
+
+  The fee portion stored in order.feeBps is refunded to the user.
+```
+
+### Refund Comparison
+
+| Scenario | What Is Refunded | Fee Handling |
+|---|---|---|
+| SELL cancel | Remaining BASE | No fee to refund |
+| BUY cancel | QUOTE + maker fee portion | `order.feeBps` used to compute maker fee refund |
+| SELL partial fill (maker) | Remaining BASE at cancel | Executed portion had fee deducted |
+| BUY partial fill (maker) | Remaining QUOTE + fee at cancel | Executed portion had fee deducted |
+| BUY limit (excess from taker→maker) | Excess QUOTE via `_returnRemainQuote()` | Difference between taker and maker fee pre-funding |
+
+---
+
+## 💾 Storage Patterns
+
+The fee system uses three distinct storage patterns, each for a specific purpose:
+
+### 1. Regular Contract Storage (PairImplV3)
+
+| Variable | Type | Purpose |
+|---|---|---|
+| `feeController` | `IFeeController` | Address of the active FeeController implementation |
+| `baseReserve` | `uint256` | Total BASE held for open SELL orders |
+| `quoteReserve` | `uint256` | Total QUOTE held for open BUY orders (fee-inclusive) |
+| `_allOrders[id].feeBps` | `uint32` | Maker fee bps snapshot at order creation |
+
+### 2. ERC-7201 Namespaced Persistent Storage (FeeControllers)
+
+Both FeeController implementations use ERC-7201 to isolate their configuration from Pair's own storage. This is critical because FeeControllers execute via `delegatecall` and share the Pair's storage context.
+
+**FeeControllerV2Compat:**
+
+```
+Namespace: "cross.storage.FeeControllerV2Compat"
+Slot: keccak256("cross.storage.FeeControllerV2Compat") - 1) & ~bytes32(uint256(0xff))
+
+┌─────────────────────────────────────────────┐
+│ FeeControllerV2CompatStorage                │
+├─────────────────────────────────────────────┤
+│ address  feeCollector                       │
+│ uint32   sellerMakerFeeBps                  │
+│ uint32   sellerTakerFeeBps                  │
+│ uint32   buyerMakerFeeBps                   │
+│ uint32   buyerTakerFeeBps                   │
+│ IERC20   quote        (cached from Pair)    │
+│ uint256  denominator  (cached from Pair)    │
+└─────────────────────────────────────────────┘
+```
+
+**FeeControllerV3Split:**
+
+```
+Namespace: "cross.storage.FeeControllerV3Split"
+Slot: keccak256("cross.storage.FeeControllerV3Split") - 1) & ~bytes32(uint256(0xff))
+
+┌─────────────────────────────────────────────┐
+│ FeeControllerV3SplitStorage                 │
+├─────────────────────────────────────────────┤
+│ address  feeCollector                       │
+│ address  creator                            │
+│ uint32   takerFeeBps                        │
+│ uint32   creatorShareBps                    │
+│ uint32   makerRebateShareBps                │
+│ IERC20   quote        (cached from Pair)    │
+│ uint256  denominator  (cached from Pair)    │
+└─────────────────────────────────────────────┘
+```
+
+### 3. ERC-7201 Namespaced Transient Storage (EIP-1153)
+
+Per-transaction fee accumulators use transient storage to avoid permanent writes. These are automatically cleared at the end of each transaction.
+
+**FeeControllerV2Compat Transient Layout:**
+
+```
+Base slot: keccak256("cross.transient.FeeControllerV2Compat") - 1) & ~bytes32(uint256(0xff))
+
+Slot + 0: currentTakerId   (uint256)  — taker order ID for this match set
+Slot + 1: takerFeeBps      (uint32)   — cached taker fee rate
+Slot + 2: makerFeeAcc      (uint256)  — accumulated maker fees
+Slot + 3: takerFeeAcc      (uint256)  — accumulated taker fees
+```
+
+**FeeControllerV3Split Transient Layout:**
+
+```
+Base slot: keccak256("cross.transient.FeeControllerV3Split") - 1) & ~bytes32(uint256(0xff))
+
+Slot + 0: currentTakerId        (uint256)  — taker order ID for this match set
+Slot + 1: takerFeeAccTotal      (uint256)  — accumulated total taker fees
+Slot + 2: makerRebatePaidTotal  (uint256)  — accumulated maker rebates already paid
+```
+
+### Storage Pattern Summary
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        Pair Storage Context                         │
+│  (FeeController runs here via delegatecall)                         │
+│                                                                     │
+│  ┌──────────────────────────────────────┐                           │
+│  │ Regular Storage (PairImplV3)         │                           │
+│  │  - feeController address             │                           │
+│  │  - baseReserve, quoteReserve         │                           │
+│  │  - _allOrders[].feeBps              │                           │
+│  └──────────────────────────────────────┘                           │
+│                                                                     │
+│  ┌──────────────────────────────────────┐                           │
+│  │ ERC-7201 Persistent Storage          │  ← Namespaced, isolated  │
+│  │  - Fee config (bps rates)            │                           │
+│  │  - feeCollector address              │                           │
+│  │  - Cached quote/denominator          │                           │
+│  └──────────────────────────────────────┘                           │
+│                                                                     │
+│  ┌──────────────────────────────────────┐                           │
+│  │ ERC-7201 Transient Storage (EIP-1153)│  ← Auto-cleared per tx   │
+│  │  - currentTakerId                    │                           │
+│  │  - Fee accumulators                  │                           │
+│  └──────────────────────────────────────┘                           │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### Why Three Storage Patterns?
+
+| Pattern | Reason |
+|---|---|
+| **Regular** | Pair's core state (reserves, orders) — must be persistent and directly accessible |
+| **ERC-7201 Persistent** | FeeController config must live in Pair's storage (delegatecall) but be isolated to prevent slot collisions. Namespacing guarantees no overlap with Pair's own variables. |
+| **ERC-7201 Transient** | Per-transaction accumulators (fee totals) only need to live for the duration of one match set. Transient storage (EIP-1153) avoids SSTORE costs and is automatically zeroed at tx end. |
+
+---
 
 ## ✅ Allow-list and Safety Checks
 
@@ -171,10 +712,36 @@ FeeControllers are gated at the CrossDex level:
 - `CrossDexImplV3` stores an allow-list of FeeController addresses.
 - `MarketImplV3` and `PairImplV3` require new FeeControllers to be allowed by CrossDex.
 
+### Validation Chain
+
+```
+setFeeController(newController, initData)
+  │
+  ├─ PairImplV3.setFeeController()
+  │   └─ IMarketV3(MARKET).checkFeeControllerAllowed(newController)
+  │       └─ ICrossDexV3(CROSS_DEX).checkFeeControllerAllowed(newController)
+  │           └─ Verify: _allowedFeeControllers.contains(newController)
+  │
+  └─ If allowed:
+      ├─ Update feeController address
+      ├─ delegatecall: initialize(quote, denominator, initData)
+      └─ Emit FeeControllerUpdated(before, current)
+```
+
+### ERC-165 Validation
+
+When adding a FeeController to the allow-list, CrossDex verifies ERC-165 support:
+
+```solidity
+IERC165(feeController).supportsInterface(type(IFeeController).interfaceId)
+```
+
 This matters especially for upgrades:
 
 - after upgrading CrossDex to V3, the allow-list starts empty
 - you must call `CrossDexImplV3.setFeeControllerAllow(feeController, true)` before setting it on Markets/Pairs
+
+---
 
 ## 🧪 Configuration Examples
 
@@ -202,3 +769,74 @@ bytes memory initData = abi.encode(
 );
 ```
 
+---
+
+## 🔌 Integration Guide
+
+### For External Systems / Frontends
+
+#### Reading Fee Configuration
+
+```solidity
+// Get the 4-rate fee structure (works for both V2Compat and V3Split)
+(uint32 smf, uint32 stf, uint32 bmf, uint32 btf) = IPairV3(pair).getEffectiveFees();
+
+// Get FeeController type
+(bytes32 configId, bytes memory data) = IPairV3(pair).getFeeControllerConfig();
+// configId == "FeeControllerV2Compat.v1" or "FeeControllerV3Split.v1"
+```
+
+#### Computing Required Deposit for BUY Orders
+
+```solidity
+// For a BUY limit order at price P for amount A:
+uint256 volume = price * amount / DENOMINATOR;
+uint256 requiredDeposit = IPairV3(pair).calcBuyVolumeWithFee(volume);
+
+// For a BUY market order spending Q QUOTE:
+uint256 requiredDeposit = IPairV3(pair).calcBuyVolumeWithFee(quoteVolume);
+```
+
+#### Important Notes for Integrators
+
+1. **Always use the Router** for order submission. Direct Pair calls will fail (onlyRouter modifier).
+
+2. **Fee controller type matters for fee distribution:**
+   - V2Compat: fees go to a single `feeCollector`
+   - V3Split: fees split between `feeCollector`, `creator`, and makers (rebates)
+
+3. **BUY order deposits are always fee-inclusive.** Use `calcBuyVolumeWithFee()` to get the exact amount.
+
+4. **SELL order deposits have no fee.** Transfer the exact BASE amount.
+
+5. **Fee rates can change.** Maker fee bps is snapshotted in `order.feeBps` at creation. Taker fee bps is read at match time. If fees change between order creation and execution, the maker pays the old rate and the taker pays the new rate.
+
+6. **Cancel refunds include fee pre-funding** for BUY orders. The refund formula uses the snapshotted `order.feeBps`.
+
+### Events to Monitor
+
+| Event | Emitted By | Purpose |
+|---|---|---|
+| `FeeCollect(orderId, owner, amount, fee, value)` | PairImplV3 | Per-order fee deduction from trader's perspective |
+| `FeeControllerFeesSettled(takerId, feeCollector, totalFee)` | FeeControllerV2Compat | Total fees sent to feeCollector per match set |
+| `FeeControllerV3FeesSettled(takerId, totalTakerFee, creatorFee, feeCollectorFee, makerRebatePaidTotal, creator, feeCollector)` | FeeControllerV3Split | Detailed fee split per match set |
+| `FeeControllerV3MakerRebatePaid(orderId, maker, rebate)` | FeeControllerV3Split | Individual maker rebate payment |
+| `FeeControllerUpdated(before, current)` | PairImplV3 / MarketImplV3 | FeeController address change |
+| `FeeControllerAllowed(feeController, allowed)` | CrossDexImplV3 | Allow-list change |
+
+### Comparison: V2Compat vs V3Split
+
+| Aspect | V2Compat | V3Split |
+|---|---|---|
+| **Config ID** | `FeeControllerV2Compat.v1` | `FeeControllerV3Split.v1` |
+| **Fee Rates** | 4 independent rates (maker/taker × seller/buyer) | 1 taker rate + split shares |
+| **Maker Fee** | Per-side configurable (seller/buyer) | Always 0 |
+| **Taker Fee** | Per-side configurable (seller/buyer) | Uniform (single rate) |
+| **Fee Recipients** | Single `feeCollector` | `feeCollector` + `creator` + makers (rebate) |
+| **Maker Rebate** | No | Yes (immediate, during matching) |
+| **Transfers in recordMatch** | None | Maker rebate transfer |
+| **Transfers in settleFees** | Total to feeCollector | Split: creator + feeCollector |
+| **BUY Reserve Calculation** | `volume + volume * buyerMakerFeeBps / 10000` | `volume` (maker fee is 0) |
+| **order.feeBps for SELL** | `sellerMakerFeeBps` | 0 |
+| **order.feeBps for BUY** | `buyerMakerFeeBps` | 0 |
+| **Cancel refund (BUY)** | Includes maker fee portion | Volume only (no maker fee) |

--- a/src/CrossDexImplV3.sol
+++ b/src/CrossDexImplV3.sol
@@ -38,7 +38,7 @@ contract CrossDexImplV3 is UUPSUpgradeable, OwnableUpgradeable, ICrossDexV3 {
     address public marketImpl;
     address public pairImpl;
 
-    EnumerableMap.AddressToAddressMap private _allMarkets; // market => quote (update v2)
+    EnumerableMap.AddressToAddressMap private _allMarkets; // market => quote
     mapping(address pair => address) public override pairToMarket;
 
     address public tickSizeSetter;

--- a/src/CrossDexImplV3.sol
+++ b/src/CrossDexImplV3.sol
@@ -190,6 +190,9 @@ contract CrossDexImplV3 is UUPSUpgradeable, OwnableUpgradeable, ICrossDexV3 {
     }
 
     function setFeeControllerAllow(address feeController, bool allowed) external onlyOwner {
+        // CDC-09: Explicit zero address validation
+        if (feeController == address(0)) revert CrossDexInvalidFeeController(feeController);
+
         bool ok;
 
         if (allowed) {

--- a/src/CrossDexImplV3.sol
+++ b/src/CrossDexImplV3.sol
@@ -42,9 +42,10 @@ contract CrossDexImplV3 is UUPSUpgradeable, OwnableUpgradeable, ICrossDexV3 {
     mapping(address pair => address) public override pairToMarket;
 
     address public tickSizeSetter;
-    EnumerableSet.AddressSet private _allowedFeeControllers;
+    EnumerableSet.AddressSet private _allowedFeeControllers; // 2 slots
 
-    uint256[42] __gap;
+    // Storage gap reduced from 42 to 40 to account for _allowedFeeControllers (2 slots)
+    uint256[40] __gap;
 
     modifier onlyMarket() {
         _checkMarket();

--- a/src/CrossDexImplV3.sol
+++ b/src/CrossDexImplV3.sol
@@ -94,6 +94,14 @@ contract CrossDexImplV3 is UUPSUpgradeable, OwnableUpgradeable, ICrossDexV3 {
         onlyOwner
         reinitializer(3)
     {
+        // CDC-10: Add zero address validation
+        if (_marketImpl == address(0)) revert CrossDexInitializeData("marketImpl");
+        if (_pairImpl == address(0)) revert CrossDexInitializeData("pairImpl");
+
+        // CDC-10: Emit events for state changes
+        emit MarketImplSet(marketImpl, _marketImpl);
+        emit PairImplSet(pairImpl, _pairImpl);
+
         marketImpl = _marketImpl;
         pairImpl = _pairImpl;
         for (uint256 i = 0; i < _feeControllers.length; ++i) {

--- a/src/CrossDexImplV3.sol
+++ b/src/CrossDexImplV3.sol
@@ -33,7 +33,7 @@ contract CrossDexImplV3 is UUPSUpgradeable, OwnableUpgradeable, ICrossDexV3 {
     event MarketImplSet(address indexed before, address indexed current);
     event FeeControllerAllowed(address indexed feeController, bool indexed allowed);
 
-    address payable public ROUTER; // immutable
+    address payable public ROUTER; // set once in initialize
 
     address public marketImpl;
     address public pairImpl;

--- a/src/CrossDexImplV3.sol
+++ b/src/CrossDexImplV3.sol
@@ -94,11 +94,11 @@ contract CrossDexImplV3 is UUPSUpgradeable, OwnableUpgradeable, ICrossDexV3 {
         onlyOwner
         reinitializer(3)
     {
-        // CDC-10: Add zero address validation
+        // Add zero address validation
         if (_marketImpl == address(0)) revert CrossDexInitializeData("marketImpl");
         if (_pairImpl == address(0)) revert CrossDexInitializeData("pairImpl");
 
-        // CDC-10: Emit events for state changes
+        // Emit events for state changes
         emit MarketImplSet(marketImpl, _marketImpl);
         emit PairImplSet(pairImpl, _pairImpl);
 
@@ -154,7 +154,7 @@ contract CrossDexImplV3 is UUPSUpgradeable, OwnableUpgradeable, ICrossDexV3 {
         onlyOwner
         returns (address)
     {
-        // CDC-07: Validate fee controller is in allowed list before market creation
+        // Validate fee controller is in allowed list before market creation
         if (!_allowedFeeControllers.contains(feeController)) revert CrossDexInvalidFeeController(feeController);
 
         bytes memory bytecode = abi.encodePacked(
@@ -198,7 +198,7 @@ contract CrossDexImplV3 is UUPSUpgradeable, OwnableUpgradeable, ICrossDexV3 {
     }
 
     function setFeeControllerAllow(address feeController, bool allowed) external onlyOwner {
-        // CDC-09: Explicit zero address validation
+        // Explicit zero address validation
         if (feeController == address(0)) revert CrossDexInvalidFeeController(feeController);
 
         bool ok;

--- a/src/CrossDexImplV3.sol
+++ b/src/CrossDexImplV3.sol
@@ -146,6 +146,9 @@ contract CrossDexImplV3 is UUPSUpgradeable, OwnableUpgradeable, ICrossDexV3 {
         onlyOwner
         returns (address)
     {
+        // CDC-07: Validate fee controller is in allowed list before market creation
+        if (!_allowedFeeControllers.contains(feeController)) revert CrossDexInvalidFeeController(feeController);
+
         bytes memory bytecode = abi.encodePacked(
             type(ERC1967Proxy).creationCode,
             abi.encode(

--- a/src/FeeControllerV2Compat.sol
+++ b/src/FeeControllerV2Compat.sol
@@ -215,6 +215,7 @@ contract FeeControllerV2Compat is IFeeController, ERC165 {
         // Effects: Reset transient storage BEFORE external call (CEI pattern)
         // Always reset even if totalFee == 0 to allow subsequent trades in same tx
         _tstoreTakerId(0);
+        _tstoreTakerFeeBps(0); // CDC-11: Reset takerFeeBps as well
         _tstoreMakerFeeAcc(0);
         _tstoreTakerFeeAcc(0);
 

--- a/src/FeeControllerV2Compat.sol
+++ b/src/FeeControllerV2Compat.sol
@@ -120,7 +120,8 @@ contract FeeControllerV2Compat is IFeeController, ERC165 {
             $.quote = IERC20(quote);
             $.denominator = denominator;
         } else {
-            if (address($.quote) != address(quote)) revert FeeControllerInvalidPairConfig(quote, denominator);
+            // CDC-04: Remove redundant address cast
+            if (address($.quote) != quote) revert FeeControllerInvalidPairConfig(quote, denominator);
         }
     }
 
@@ -191,8 +192,11 @@ contract FeeControllerV2Compat is IFeeController, ERC165 {
         uint32 makerBps = maker.feeBps;
 
         // Accumulate fees in transient storage
-        if (makerBps != 0) makerFee = Math.mulDiv(tradeQuoteAmount, makerBps, BPS_DENOMINATOR);
-        _tstoreMakerFeeAcc(_tloadMakerFeeAcc() + makerFee);
+        // CDC-05: Skip transient storage access when makerBps is 0
+        if (makerBps != 0) {
+            makerFee = Math.mulDiv(tradeQuoteAmount, makerBps, BPS_DENOMINATOR);
+            _tstoreMakerFeeAcc(_tloadMakerFeeAcc() + makerFee);
+        }
 
         if (takerBps != 0) {
             uint256 takerFee = Math.mulDiv(tradeQuoteAmount, takerBps, BPS_DENOMINATOR);

--- a/src/FeeControllerV2Compat.sol
+++ b/src/FeeControllerV2Compat.sol
@@ -117,6 +117,7 @@ contract FeeControllerV2Compat is IFeeController, ERC165 {
         $.buyerTakerFeeBps = bTk;
         // Note: fee accumulators are in transient storage, auto-reset per transaction
         if (address($.quote) == address(0)) {
+            if (quote == address(0)) revert FeeControllerInvalidPairConfig(quote, denominator);
             $.quote = IERC20(quote);
             $.denominator = denominator;
         } else {

--- a/src/FeeControllerV2Compat.sol
+++ b/src/FeeControllerV2Compat.sol
@@ -120,7 +120,7 @@ contract FeeControllerV2Compat is IFeeController, ERC165 {
             $.quote = IERC20(quote);
             $.denominator = denominator;
         } else {
-            // CDC-04: Remove redundant address cast
+            // Remove redundant address cast
             if (address($.quote) != quote) revert FeeControllerInvalidPairConfig(quote, denominator);
         }
     }
@@ -192,7 +192,7 @@ contract FeeControllerV2Compat is IFeeController, ERC165 {
         uint32 makerBps = maker.feeBps;
 
         // Accumulate fees in transient storage
-        // CDC-05: Skip transient storage access when makerBps is 0
+        // Skip transient storage access when makerBps is 0
         if (makerBps != 0) {
             makerFee = Math.mulDiv(tradeQuoteAmount, makerBps, BPS_DENOMINATOR);
             _tstoreMakerFeeAcc(_tloadMakerFeeAcc() + makerFee);
@@ -219,7 +219,7 @@ contract FeeControllerV2Compat is IFeeController, ERC165 {
         // Effects: Reset transient storage BEFORE external call (CEI pattern)
         // Always reset even if totalFee == 0 to allow subsequent trades in same tx
         _tstoreTakerId(0);
-        _tstoreTakerFeeBps(0); // CDC-11: Reset takerFeeBps as well
+        _tstoreTakerFeeBps(0); // Reset takerFeeBps as well
         _tstoreMakerFeeAcc(0);
         _tstoreTakerFeeAcc(0);
 

--- a/src/FeeControllerV2Compat.sol
+++ b/src/FeeControllerV2Compat.sol
@@ -81,7 +81,7 @@ contract FeeControllerV2Compat is IFeeController, ERC165 {
         _SELF = address(this);
     }
 
-    /// @dev Ensures the function is called via delegatecall (msg.sender != address(this) in original context).
+    /// @dev Ensures the function is called via delegatecall (address(this) != _SELF, i.e. executing in caller's context).
     modifier onlyDelegateCall() {
         _checkDelegateCall();
         _;
@@ -96,7 +96,7 @@ contract FeeControllerV2Compat is IFeeController, ERC165 {
     // ─────────────────────────────────────────────────────────────────────────────
 
     /// @notice Initialize or update fee configuration.
-    /// @dev Called via delegatecall from Pair. Reads QUOTE/DENOMINATOR from Pair's storage directly.
+    /// @dev Called via delegatecall from Pair. Receives QUOTE/DENOMINATOR as parameters from Pair.
     /// @param initData abi.encode(feeCollector, sellerMakerBps, sellerTakerBps, buyerMakerBps, buyerTakerBps)
     function initialize(address quote, uint256 denominator, bytes memory initData) external override onlyDelegateCall {
         (address _feeCollector, uint32 sMk, uint32 sTk, uint32 bMk, uint32 bTk) =

--- a/src/FeeControllerV3Split.sol
+++ b/src/FeeControllerV3Split.sol
@@ -142,6 +142,7 @@ contract FeeControllerV3Split is IFeeController, ERC165 {
 
         // Cache quote/denominator from Pair (immutable after first init)
         if (address($.quote) == address(0)) {
+            if (quote == address(0)) revert FeeControllerInvalidPairConfig(quote, denominator);
             $.quote = IERC20(quote);
             $.denominator = denominator;
         } else {

--- a/src/FeeControllerV3Split.sol
+++ b/src/FeeControllerV3Split.sol
@@ -41,10 +41,10 @@ contract FeeControllerV3Split is IFeeController, ERC165 {
         address indexed feeCollector
     );
 
-    /// @notice Emitted when maker rebate is paid.
-    /// @param orderId The order ID that initiated this fee settlement
-    /// @param maker The maker order (maker.owner receives rebate)
-    /// @param rebate The amount of maker rebate paid
+    /// @notice Emitted when maker rebate is paid during matching.
+    /// @param orderId The maker order ID receiving the rebate
+    /// @param maker The maker address that receives the rebate
+    /// @param rebate The amount of QUOTE rebated to the maker
     event FeeControllerV3MakerRebatePaid(uint256 indexed orderId, address indexed maker, uint256 rebate);
 
     // ─────────────────────────────────────────────────────────────────────────────

--- a/src/MarketImplV3.sol
+++ b/src/MarketImplV3.sol
@@ -70,6 +70,8 @@ contract MarketImplV3 is UUPSUpgradeable, OwnableUpgradeable, IMarketV3 {
 
     function reInitialize(address _pairImpl, address _feeController) external onlyOwner reinitializer(3) {
         if (_pairImpl == address(0)) revert MarketInvalidInitializeData("pairImpl");
+        // CDC-09: Explicit zero address validation for feeController
+        if (_feeController == address(0)) revert MarketInvalidInitializeData("feeController");
         CROSS_DEX.checkFeeControllerAllowed(_feeController);
 
         pairImpl = _pairImpl;

--- a/src/MarketImplV3.sol
+++ b/src/MarketImplV3.sol
@@ -70,11 +70,11 @@ contract MarketImplV3 is UUPSUpgradeable, OwnableUpgradeable, IMarketV3 {
 
     function reInitialize(address _pairImpl, address _feeController) external onlyOwner reinitializer(3) {
         if (_pairImpl == address(0)) revert MarketInvalidInitializeData("pairImpl");
-        // CDC-09: Explicit zero address validation for feeController
+        // Explicit zero address validation for feeController
         if (_feeController == address(0)) revert MarketInvalidInitializeData("feeController");
         CROSS_DEX.checkFeeControllerAllowed(_feeController);
 
-        // CDC-10: Emit events for state changes
+        // Emit events for state changes
         emit PairImplSet(pairImpl, _pairImpl);
         emit FeeControllerUpdated(feeController, _feeController);
 

--- a/src/MarketImplV3.sol
+++ b/src/MarketImplV3.sol
@@ -28,10 +28,10 @@ contract MarketImplV3 is UUPSUpgradeable, OwnableUpgradeable, IMarketV3 {
     event PairImplSet(address indexed before, address indexed current);
     event FeeControllerUpdated(address indexed before, address indexed current);
 
-    uint256 public deployed; // immutable
-    ICrossDexV3 public CROSS_DEX; // immutable
-    address public QUOTE; // immutable
-    address public ROUTER; // immutable
+    uint256 public deployed; // set once in initialize
+    ICrossDexV3 public CROSS_DEX; // set once in initialize
+    address public QUOTE; // set once in initialize
+    address public ROUTER; // set once in initialize
 
     address public pairImpl;
 
@@ -46,7 +46,7 @@ contract MarketImplV3 is UUPSUpgradeable, OwnableUpgradeable, IMarketV3 {
         _disableInitializers();
     }
 
-    // Initialize with 4 different fee rates encoded in bytes data
+    /// @notice Initialize market with owner, router, quote token, pair implementation, and fee controller.
     function initialize(address _owner, address _router, address _quote, address _pairImpl, address _feeController)
         external
         override
@@ -70,7 +70,6 @@ contract MarketImplV3 is UUPSUpgradeable, OwnableUpgradeable, IMarketV3 {
 
     function reInitialize(address _pairImpl, address _feeController) external onlyOwner reinitializer(3) {
         if (_pairImpl == address(0)) revert MarketInvalidInitializeData("pairImpl");
-        // Explicit zero address validation for feeController
         if (_feeController == address(0)) revert MarketInvalidInitializeData("feeController");
         CROSS_DEX.checkFeeControllerAllowed(_feeController);
 

--- a/src/MarketImplV3.sol
+++ b/src/MarketImplV3.sol
@@ -74,6 +74,10 @@ contract MarketImplV3 is UUPSUpgradeable, OwnableUpgradeable, IMarketV3 {
         if (_feeController == address(0)) revert MarketInvalidInitializeData("feeController");
         CROSS_DEX.checkFeeControllerAllowed(_feeController);
 
+        // CDC-10: Emit events for state changes
+        emit PairImplSet(pairImpl, _pairImpl);
+        emit FeeControllerUpdated(feeController, _feeController);
+
         pairImpl = _pairImpl;
         feeController = _feeController;
     }

--- a/src/PairImplV3.sol
+++ b/src/PairImplV3.sol
@@ -53,16 +53,15 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
     event Skim(address indexed caller, address indexed erc20, address indexed to, uint256 amount);
     event FeeControllerUpdated(address indexed before, address indexed current);
 
-    // slots
+    // Transient storage slot for caching the latest matched price within a transaction.
     // keccak256(abi.encode(uint256(keccak256("crossdex.pair.matchedprice")) - 1)) & ~bytes32(uint256(0xff))
-    // solhint-disable-next-line const-name-snakecase
     bytes32 private constant MATCHED_PRICE_SLOT = 0xfd0e5d4f9b88892d3b04349a0e2bc0d1359414c21932fcd7d5a523a6c0a5cd00;
 
-    address public MARKET; // immutable
-    address public ROUTER; // immutable
-    IERC20 public BASE; // immutable
-    IERC20 public QUOTE; // immutable
-    uint256 public DENOMINATOR; // immutable ( == 10 ** BASE.decimals())
+    address public MARKET; // set once in initialize
+    address public ROUTER; // set once in initialize
+    IERC20 public BASE; // set once in initialize
+    IERC20 public QUOTE; // set once in initialize
+    uint256 public DENOMINATOR; // set once in initialize ( == 10 ** BASE.decimals())
 
     // reserves
     uint256 public baseReserve;
@@ -79,13 +78,13 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
 
     // orders
     uint256 private _orderIdCounter;
-    List.U256[2] private _prices; // 0: sell, 1: buy (IPair.OrderSide)
+    List.U256[2] private _prices; // 0: sell, 1: buy (IPairV3.OrderSide)
     mapping(uint256 price => List.U256) private _sellOrders; // price => sell order id list (For the same price, orders will be stored in chronological order.)
     mapping(uint256 price => List.U256) private _buyOrders; //  price => buy order id list (For the same price, orders will be stored in chronological order.)
     mapping(uint256 orderId => Order) private _allOrders;
     mapping(address account => uint256[2]) private _accountReserves; // 0: sell (base), 1: buy (quote)
 
-    // Pair-specific fee configuration (replaces V2's feeConfig struct in same storage slot)
+    // Fee policy implementation executed via delegatecall (stores config in ERC-7201 namespaced storage)
     IFeeController public feeController;
 
     uint256[24] private __gap;
@@ -308,15 +307,15 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
                 _allOrders[orderId] = order;
 
                 if (isSellOrder) {
-                    // Set maker fee bps for V2 compatibility (used in cancel refund)
+                    // Snapshot maker fee bps (used in maker fee calculation and cancel refund)
                     _allOrders[orderId].feeBps = _feeControllerSellerMakerFeeBps();
                     _addBaseReserve(order.owner, order.amount);
                     _sellOrders[order.price].push(orderId);
                 } else {
-                    // Set maker fee bps for V2 compatibility (used in cancel refund)
+                    // Snapshot maker fee bps (used in maker fee calculation and cancel refund)
                     _allOrders[orderId].feeBps = _feeControllerBuyerMakerFeeBps();
-                    // For V2 RouterV2, the fee is already included in the transferred amount
-                    // So we use the actual received amount instead of calculating fee again
+                    // The Router transfers fee-inclusive QUOTE, so we calculate
+                    // the reserve amount using maker fee instead of recalculating from scratch
                     uint256 reserveQuoteAmount = _feeControllerCalcBuyVolumeWithFeeOrder(true, order);
                     _addQuoteReserve(order.owner, reserveQuoteAmount);
                     _buyOrders[order.price].push(orderId);
@@ -551,7 +550,7 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
                 (address makerOwner, uint256 tradeAmount, uint256 makerFee) =
                     _matchOrderAmount(orderId, order, makerId, maker, cache.price, _orders);
                 uint256 tradeQuoteAmount = Math.mulDiv(cache.price, tradeAmount, DENOMINATOR);
-                // Trade executed. ( Calculate using the fee rate at the time the seller registered the sale.)
+                // Transfer QUOTE to sell-maker after deducting makerFee (from maker's order.feeBps)
                 _exchangeSellOrder(makerId, makerOwner, tradeQuoteAmount, makerFee);
 
                 // Update information.
@@ -824,7 +823,6 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
     }
 
     function _feeControllerCalcBuyVolumeWithFee(bool isMaker, uint256 volume) private returns (uint256) {
-        // calcBuyVolumeWithFee(bool,uint256)
         bytes memory result = Address.functionDelegateCall(
             address(feeController), abi.encodeCall(IFeeController.calcBuyVolumeWithFee, (isMaker, volume))
         );
@@ -832,7 +830,6 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
     }
 
     function _feeControllerCalcBuyVolumeWithFeeOrder(bool isMaker, Order memory order) private returns (uint256) {
-        // calcBuyVolumeWithFee(bool,(uint8,address,uint32,uint256,uint256)) - Order struct
         bytes memory result = Address.functionDelegateCall(
             address(feeController), abi.encodeCall(IFeeController.calcBuyVolumeWithFeeByOrder, (isMaker, order))
         );

--- a/src/PairImplV3.sol
+++ b/src/PairImplV3.sol
@@ -85,7 +85,7 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
     mapping(uint256 orderId => Order) private _allOrders;
     mapping(address account => uint256[2]) private _accountReserves; // 0: sell (base), 1: buy (quote)
 
-    // Pair-specific fee configuration
+    // Pair-specific fee configuration (replaces V2's feeConfig struct in same storage slot)
     IFeeController public feeController;
 
     uint256[24] private __gap;

--- a/src/PairImplV3.sol
+++ b/src/PairImplV3.sol
@@ -153,11 +153,11 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
         onlyOwner
         reinitializer(3)
     {
-        // CDC-10: Explicit zero address validation
+        // Explicit zero address validation
         if (_feeController == address(0)) revert PairInvalidInitializeData("feeController");
         IMarketV3(MARKET).checkFeeControllerAllowed(_feeController);
 
-        // CDC-10: Emit event for state change
+        // Emit event for state change
         emit FeeControllerUpdated(address(feeController), _feeController);
 
         feeController = IFeeController(_feeController);

--- a/src/PairImplV3.sol
+++ b/src/PairImplV3.sol
@@ -504,7 +504,6 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
         uint256 matchedBaseAmount;
         uint256 useQuoteAmount;
         uint256 baseReserve;
-        uint256 totalTakerFee;
         bool done;
     }
 
@@ -524,7 +523,7 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
         returns (bool, uint256, uint256)
     {
         MatchBuyCache memory cache = MatchBuyCache({
-            price: 0, matchedBaseAmount: 0, useQuoteAmount: 0, baseReserve: baseReserve, totalTakerFee: 0, done: false
+            price: 0, matchedBaseAmount: 0, useQuoteAmount: 0, baseReserve: baseReserve, done: false
         });
 
         List.U256 storage _sellPrices = _prices[uint8(OrderSide.SELL)];

--- a/src/PairImplV3.sol
+++ b/src/PairImplV3.sol
@@ -153,7 +153,13 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
         onlyOwner
         reinitializer(3)
     {
+        // CDC-10: Explicit zero address validation
+        if (_feeController == address(0)) revert PairInvalidInitializeData("feeController");
         IMarketV3(MARKET).checkFeeControllerAllowed(_feeController);
+
+        // CDC-10: Emit event for state change
+        emit FeeControllerUpdated(address(feeController), _feeController);
+
         feeController = IFeeController(_feeController);
         _feeControllerInitialize(feeControllerInitData);
     }

--- a/src/PairImplV3.sol
+++ b/src/PairImplV3.sol
@@ -424,9 +424,8 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
 
         // 3. Transfer the immediately settled BASE tokens.
         if (buyBaseAmount != 0) {
-            // Process buyer fee
-            _exchangeBuyOrder(orderId, order.owner, buyBaseAmount, useQuoteAmount, 0);
             uint256 takerFee = _feeControllerSettleFees();
+            BASE.safeTransfer(order.owner, buyBaseAmount);
             if (takerFee != 0) {
                 emit FeeCollect(orderId, order.owner, useQuoteAmount, takerFee, useQuoteAmount - takerFee);
             }
@@ -522,9 +521,8 @@ contract PairImplV3 is UUPSUpgradeable, PausableUpgradeable, IPairV3, IOwnable {
         setLatest
         returns (bool, uint256, uint256)
     {
-        MatchBuyCache memory cache = MatchBuyCache({
-            price: 0, matchedBaseAmount: 0, useQuoteAmount: 0, baseReserve: baseReserve, done: false
-        });
+        MatchBuyCache memory cache =
+            MatchBuyCache({price: 0, matchedBaseAmount: 0, useQuoteAmount: 0, baseReserve: baseReserve, done: false});
 
         List.U256 storage _sellPrices = _prices[uint8(OrderSide.SELL)];
         while (!_sellPrices.empty()) {

--- a/test/CrossDexImplV3.t.sol
+++ b/test/CrossDexImplV3.t.sol
@@ -249,6 +249,18 @@ contract CrossDexImplV3Test is DEXV3BaseTest {
         assertEq(logs.length, 0, "No event should be emitted for duplicate remove");
     }
 
+    // CDC-09: setFeeControllerAllow should revert for zero address
+    function test_setFeeControllerAllow_revert_zeroAddress() external {
+        vm.prank(OWNER);
+        vm.expectRevert(abi.encodeWithSelector(CrossDexImplV3.CrossDexInvalidFeeController.selector, address(0)));
+        CROSS_DEX.setFeeControllerAllow(address(0), true);
+
+        // Also test with allowed=false
+        vm.prank(OWNER);
+        vm.expectRevert(abi.encodeWithSelector(CrossDexImplV3.CrossDexInvalidFeeController.selector, address(0)));
+        CROSS_DEX.setFeeControllerAllow(address(0), false);
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Access Control Tests
     // ═══════════════════════════════════════════════════════════════════════════

--- a/test/CrossDexImplV3.t.sol
+++ b/test/CrossDexImplV3.t.sol
@@ -113,6 +113,18 @@ contract CrossDexImplV3Test is DEXV3BaseTest {
         CROSS_DEX.createMarket(OWNER, address(newQuote), address(FEE_CONTROLLER), "test");
     }
 
+    // CDC-07: createMarket should revert if feeController is not in allowed list
+    function test_createMarket_revert_invalidFeeController() external {
+        T20 newQuote = new T20("QUOTE2", "Q2", 18);
+        address invalidFeeController = address(0x9999);
+
+        vm.prank(OWNER);
+        vm.expectRevert(
+            abi.encodeWithSelector(CrossDexImplV3.CrossDexInvalidFeeController.selector, invalidFeeController)
+        );
+        CROSS_DEX.createMarket(OWNER, address(newQuote), invalidFeeController, "test");
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════
     // Admin Functions Tests
     // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## 요약

V3 컨트랙트에 대한 예비 감사(PRE-Cross-Dex-Contract-V3) 결과를 반영합니다.

### 보안 수정 사항 (Medium/Minor)

- **CDC-06**: `CrossDexImplV3`의 Storage Gap 관리 오류 수정
  - `_allowedFeeControllers`가 2개 슬롯을 사용하므로 `__gap`을 42에서 40으로 변경
  
- **CDC-07**: Market 생성 시 Fee Controller 검증 불일치 수정
  - `createMarket()`에서 fee controller 허용 목록 검증 추가
  
- **CDC-09**: Zero Address 검증 누락 수정
  - `setFeeControllerAllow()`, `reInitialize()` 함수들에 명시적 검증 추가
  
- **CDC-10**: reInitialize 함수 검증/이벤트 강화
  - `CrossDexImplV3`, `MarketImplV3`, `PairImplV3`의 reInitialize에 이벤트 발행 추가
  
- **CDC-11**: Transient Storage 리셋 누락 수정
  - `FeeControllerV2Compat.settleFees()`에서 `takerFeeBps` 리셋 추가

### 코드 품질 (Informational)

- **CDC-12**: 오래된 주석 정리
  - V2 관련 불필요한 주석 제거 및 storage 호환성 문서화

### Gas 최적화

- **CDC-02**: `MatchBuyCache`의 미사용 `totalTakerFee` 필드 제거
- **CDC-04**: `FeeControllerV2Compat.initialize()`의 불필요한 address 캐스팅 제거
- **CDC-05**: `recordMatch()`에서 makerBps == 0일 때 transient storage 접근 스킵

### 적용하지 않은 항목

- **CDC-08**: `__UUPSUpgradeable_init()` 호출 누락
  - OpenZeppelin 5.x에서 해당 함수가 no-op이므로 실제 영향 없음
- **CDC-03**: `isMaker=true` 경로
  - 실제로 maker order 예약 시 사용되고 있어 변경 불필요
- **CDC-13**: 복잡한 Fee 로직 분리
  - 아키텍처 검토 사항으로 향후 리팩토링 시 고려